### PR TITLE
Fixed attachment buttons non-IE Browsers

### DIFF
--- a/members/include/forum/post.php
+++ b/members/include/forum/post.php
@@ -230,8 +230,8 @@ if($blnCheckForumAttachments) {
 			"type" => "custom",
 			"sortorder" => $i++,
 			"display_name" => "Attachments",
-			"html" => "<div class='formInput'><div id='attachmentsDiv' style='margin-bottom: 10px'>
-							<input type='file' name='forumattachment_1' class='textBox' style='border: 0px'>
+			"html" => "<div id='attachmentsDiv' style='margin-bottom: 10px'>
+							<input type='file' name='forumattachment_1' style='border: 0px'>
 						</div>
 						<a href='javascript:void(0)' id='addMoreAttachments'>Add More Attachments</a></div>
 						<input type='hidden' id='numOfAttachments' value='1' name='numofattachments'>"
@@ -300,7 +300,7 @@ echo "
 				
 				if(numOfAttachments <= ".ini_get("max_file_uploads").") {
 	
-					$('#attachmentsDiv').append(\"<br><input type='file' name='forumattachment_\"+numOfAttachments+\"' class='textBox' style='border: 0px'>\");
+					$('#attachmentsDiv').append(\"<br><input type='file' name='forumattachment_\"+numOfAttachments+\"' style='border: 0px'>\");
 					$('#numOfAttachments').val(numOfAttachments);
 				
 				}


### PR DESCRIPTION
On the new post item for Forums, for non-IE browsers the text of the file name didn't show.  Also, the alignment was wonky.  

Modified line 233 to remove out the reference to the class in the CSS.  This was causing the button to be centered but depending on the browser the file name would be left or right and would look out of place.
Modified line 234 to remove "textbox" class so it will display correct in Non-IE browser.
Modified line 303 for the same reason as 234.
